### PR TITLE
Made damage multiplier be able to be any number

### DIFF
--- a/frontend/src/Routines/Activity/Damage.tsx
+++ b/frontend/src/Routines/Activity/Damage.tsx
@@ -39,6 +39,7 @@ import {
   Select,
   Slider,
   Switch,
+  TextField,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -58,6 +59,10 @@ import { damageTrendValues, dieTrendValues } from "../../Model/defaults";
 //   },
 // });
 export const Damage = ({ parentId, id }: { parentId: number; id: number }) => {
+  const damage = useAppSelector((state: RootState) => selectdamageById(state, id));
+  if (!damage) {
+    return null;
+  }
   const {
     damageCondition,
     damageType,
@@ -73,7 +78,10 @@ export const Damage = ({ parentId, id }: { parentId: number; id: number }) => {
     fatalDie,
     damageTrend,
     damageAdjustments,
-  } = useAppSelector((state: RootState) => selectdamageById(state, id)!);
+  } = damage
+
+  const [tempMultiplier, setTempMultiplier] = useState(multiplier.toString()); // Local state for TextField
+
   const dispatch = useAppDispatch();
 
   const [showContent, setShowContent] = useState(false);
@@ -201,21 +209,35 @@ export const Damage = ({ parentId, id }: { parentId: number; id: number }) => {
           </Grid>
           <Grid container spacing={{ xs: 1, sm: 2 }}>
             <Grid item>
-              <TooltipSelect
-                title="How much the damage is multiplied by. For example: if you want to average the damage of two different attacks, add both and set the multiplier to .5"
-                value={multiplier}
-                label="Multiplier"
-                onChange={(e) =>
-                  dispatch(
-                    damageUpdated({
-                      id,
-                      changes: { multiplier: Number(e.target.value) },
-                    })
-                  )
-                }
-              >
-                {multiplierOptions}
-              </TooltipSelect>
+              <Tooltip title="How much the damage is multiplied by. For example: if you want to average the damage of two different attacks, add both and set the multiplier to .5">
+                <TextField
+                  size="small"
+                  label="Multiplier"
+                  value={tempMultiplier}
+                  onChange={(e) => {
+                    setTempMultiplier(e.target.value);
+                  }}
+                  onBlur={() => {
+                    let newVal = parseFloat(tempMultiplier);
+                    if (Number.isNaN(newVal) || newVal < 0) newVal = 0;
+                    setTempMultiplier(newVal.toString());
+                    if (newVal !== multiplier) {
+                      dispatch(
+                        damageUpdated({
+                          id,
+                          changes: { multiplier: newVal },
+                        })
+                      );
+                    }
+                  }}
+                  inputProps={{
+                    step: 0.1,
+                    min: 0,
+                    type: "number",
+                  }}
+                  sx={{width: "12ch"}}
+                />
+              </Tooltip>
             </Grid>
             <Grid item>
               <FormControl size="small">

--- a/frontend/src/Routines/Activity/Damage.tsx
+++ b/frontend/src/Routines/Activity/Damage.tsx
@@ -15,7 +15,6 @@ import {
   dieTrendOptions,
   makeOptions,
   materialOptions,
-  multiplierOptions,
 } from "../../Model/options";
 import {
   DamageCond,

--- a/frontend/src/Routines/Activity/Damage.tsx
+++ b/frontend/src/Routines/Activity/Damage.tsx
@@ -59,7 +59,9 @@ import { damageTrendValues, dieTrendValues } from "../../Model/defaults";
 //   },
 // });
 export const Damage = ({ parentId, id }: { parentId: number; id: number }) => {
-  const damage = useAppSelector((state: RootState) => selectdamageById(state, id));
+  const damage = useAppSelector((state: RootState) =>
+    selectdamageById(state, id)
+  );
   if (!damage) {
     return null;
   }
@@ -78,7 +80,7 @@ export const Damage = ({ parentId, id }: { parentId: number; id: number }) => {
     fatalDie,
     damageTrend,
     damageAdjustments,
-  } = damage
+  } = damage;
 
   const [tempMultiplier, setTempMultiplier] = useState(multiplier.toString()); // Local state for TextField
 
@@ -235,7 +237,7 @@ export const Damage = ({ parentId, id }: { parentId: number; id: number }) => {
                     min: 0,
                     type: "number",
                   }}
-                  sx={{width: "12ch"}}
+                  sx={{ width: "12ch" }}
                 />
               </Tooltip>
             </Grid>

--- a/frontend/src/Routines/RoutineSlice/RoutineTypes.ts
+++ b/frontend/src/Routines/RoutineSlice/RoutineTypes.ts
@@ -218,7 +218,7 @@ function isDamages(damages: unknown): damages is Damage[] {
           Object.values(damageTypes).includes(damage.damageType) &&
           Object.values(materials).includes(damage.material) &&
           typeof damage.persistent === "boolean" &&
-          [0.5, 1, 2].includes(damage.multiplier)
+          typeof damage.multiplier === "number"
         )
       ) {
         return false;


### PR DESCRIPTION
Currently, the damage multiplier can only be 0.5, 1, or 2. This limits what we can represent - for instance, if someone won't be able to do their routine for 1 turn in a 4 turn combat, we could represent that routine neatly with a 0.75 multiplier. This pull request allows us to change it to any number.